### PR TITLE
Allow to disable colorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ TerminalColor.Red.foregroundStyleCode().open \\"\u{001B}[38;5;9m"
 TerminalColor.Red.backgroundStyleCode().open \\"\u{001B}[48;5;9m"
 ```
 
+## Disable with --no-color
+For your convenience, you can disable color without modifying any code, simply by passing the `--no-color` option in the command line:
+
+```
+$ ./example --no-color
+```
+
+
 ## License
 
 ColorizeSwift is released under the MIT license. See LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -184,23 +184,13 @@ TerminalColor.Red.backgroundStyleCode().open \\"\u{001B}[48;5;9m"
 
 ## Disable
 
-Colorization can be disabled:
+Colorization can be disabled globally:
 
 ```swift
-String.isColorizationEnabled = false
-```
+String.isColorizationEnabled = false // Default: true
 
-You can also disable colorization by passing an option (default: --no-color) to the command line:
-
-```
-$ ./example --no-color
-```
-
-The option is customizable:
-
-```swift
-String.noColorOption = "--no-color"
-String.noColorOption = nil // Disable the option
+// For example, you can support a command line option (./example --no-color)
+String.isColorizationEnabled = !CommandLine.arguments.contains("--no-color")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -182,15 +182,25 @@ TerminalColor.Red.foregroundStyleCode().open \\"\u{001B}[38;5;9m"
 TerminalColor.Red.backgroundStyleCode().open \\"\u{001B}[48;5;9m"
 ```
 
-## Disable with String.enableColor (or --no-color)
-For your (and your user's) convenience, you can disable color without modifying any code, simply by passing the `--no-color` option in the command line:
+## Disable
+
+Colorization can be disabled by setting String.isColorizationEnabled to false:
+
+```swift
+String.isColorizationEnabled = false
+```
+
+For your convenience (and your user's), you can also disable colorization without modifying any code, simply by passing an option (default: --no-color) to the command line:
 
 ```
 $ ./example --no-color
 ```
-or, it can be disabled by setting String.enableColor to false
+
+The option is customizable through String.noColorOption:
+
 ```swift
-String.enableColor = false
+String.noColorOption = "--no-color"
+String.noColorOption = nil // Disable the option
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,15 @@ TerminalColor.Red.foregroundStyleCode().open \\"\u{001B}[38;5;9m"
 TerminalColor.Red.backgroundStyleCode().open \\"\u{001B}[48;5;9m"
 ```
 
-## Disable with --no-color
-For your convenience, you can disable color without modifying any code, simply by passing the `--no-color` option in the command line:
+## Disable with String.enableColor (or --no-color)
+For your (and your user's) convenience, you can disable color without modifying any code, simply by passing the `--no-color` option in the command line:
 
 ```
 $ ./example --no-color
+```
+or, it can be disabled by setting String.enableColor to false
+```swift
+String.enableColor = false
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -184,19 +184,19 @@ TerminalColor.Red.backgroundStyleCode().open \\"\u{001B}[48;5;9m"
 
 ## Disable
 
-Colorization can be disabled by setting String.isColorizationEnabled to false:
+Colorization can be disabled:
 
 ```swift
 String.isColorizationEnabled = false
 ```
 
-For your convenience (and your user's), you can also disable colorization without modifying any code, simply by passing an option (default: --no-color) to the command line:
+You can also disable colorization by passing an option (default: --no-color) to the command line:
 
 ```
 $ ./example --no-color
 ```
 
-The option is customizable through String.noColorOption:
+The option is customizable:
 
 ```swift
 String.noColorOption = "--no-color"

--- a/Source/ColorizeSwift.swift
+++ b/Source/ColorizeSwift.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+fileprivate let colorEnabled = !CommandLine.arguments.contains("--no-color")
+
 public typealias TerminalStyleCode = (open: String, close: String)
 
 public struct TerminalStyle {
@@ -93,6 +95,7 @@ extension String {
     }
     
     public func reset() -> String {
+        guard colorEnabled else { return self }
         return  "\u{001B}[0m" + self
     }
     
@@ -109,6 +112,7 @@ extension String {
     }
     
     fileprivate func applyStyle(_ codeStyle: TerminalStyleCode) -> String {
+        guard colorEnabled else { return self }
         let str = self.replacingOccurrences(of: TerminalStyle.reset.open, with: TerminalStyle.reset.open + codeStyle.open)
         
         return codeStyle.open + str + TerminalStyle.reset.open

--- a/Source/ColorizeSwift.swift
+++ b/Source/ColorizeSwift.swift
@@ -59,32 +59,10 @@ public struct TerminalStyle {
 }
 
 extension String {
-
-	/// Enable/disable colorization
-	public static var isColorizationEnabled = true
-
-	/// Command line option disabling color
-	public static var noColorOption: String? = "--no-color" {
-		didSet {
-			String.isColorizationIgnored = isNoColorOptionPresent
-		}
-	}
-
-    fileprivate static var isColorizationIgnored: Bool = isNoColorOptionPresent
-    fileprivate static var isNoColorOptionPresent: Bool {
-        guard let option = noColorOption else { return false }
-        return CommandLine.arguments.contains(option)
-    }
-
-	/// **Should be used internally**, instead of the static method
-    fileprivate var isColorizationEnabled: Bool {
-        return !String.isColorizationIgnored && String.isColorizationEnabled
-    }
-
-}
-
-extension String {
     
+    /// Enable/disable colorization
+    public static var isColorizationEnabled = true
+
     public func bold() -> String {
         return applyStyle(TerminalStyle.bold)
     }
@@ -118,7 +96,7 @@ extension String {
     }
     
     public func reset() -> String {
-        guard isColorizationEnabled else { return self }
+        guard String.isColorizationEnabled else { return self }
         return  "\u{001B}[0m" + self
     }
     
@@ -135,7 +113,7 @@ extension String {
     }
     
     fileprivate func applyStyle(_ codeStyle: TerminalStyleCode) -> String {
-        guard isColorizationEnabled else { return self }
+        guard String.isColorizationEnabled else { return self }
         let str = self.replacingOccurrences(of: TerminalStyle.reset.open, with: TerminalStyle.reset.open + codeStyle.open)
         
         return codeStyle.open + str + TerminalStyle.reset.open

--- a/Source/ColorizeSwift.swift
+++ b/Source/ColorizeSwift.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-fileprivate let colorEnabled = !CommandLine.arguments.contains("--no-color")
+fileprivate let noColorOption = CommandLine.arguments.contains("--no-color")
 
 public typealias TerminalStyleCode = (open: String, close: String)
 
@@ -61,6 +61,11 @@ public struct TerminalStyle {
 }
 
 extension String {
+
+    public static var enableColor = true
+    private var colorEnabled: Bool {
+        return !noColorOption && String.enableColor
+    }
     
     public func bold() -> String {
         return applyStyle(TerminalStyle.bold)


### PR DESCRIPTION
Most color librairies allow this in other languages
It is especially helpful in cases where colors are not supported, like say... in XCode debugger 