### PR TITLE
Add Package@swift-4.swift

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.0
+
+//
+//  Package@swift-4.swift
+//  ColorizeSwift
+//
+//  Created by Noah Bass on 19/12/18.
+//  Copyright © 2018 Noah Bass. All rights reserved.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "ColorizeSwift",
+    products: [
+        .library(name: "ColorizeSwift", targets: ["ColorizeSwift"])
+    ],
+    targets: [
+        .target(name: "ColorizeSwift", path: "Source")
+    ]
+)


### PR DESCRIPTION
Adds support for the swift package manager v4 format.

Swift 3.x should still work w/ `Package.swift` while 4.x users should now be supported w/ `Package@swift-4.swift`.

Closes #3 